### PR TITLE
Update the handling of metadata refinement

### DIFF
--- a/lib/EBMLReader.d.ts
+++ b/lib/EBMLReader.d.ts
@@ -10,6 +10,7 @@ export default class EBMLReader extends EventEmitter {
     private metadataloaded;
     private stack;
     private chunks;
+    private segmentOffset;
     private lastSimpleBlockVideoTrackTimecode;
     private lastClusterTimecode;
     private lastClusterPosition;
@@ -36,6 +37,8 @@ export default class EBMLReader extends EventEmitter {
      * 単位 timecodeScale
      */
     private readonly duration;
+    /** emit on every segment **/
+    addListener(event: "segment_offset", listener: (ev: number) => void): this;
     /** emit on every cluster element start */
     addListener(event: "cluster_ptr", listener: (ev: number) => void): this;
     /** emit on every cue point */

--- a/lib/EBMLReader.js
+++ b/lib/EBMLReader.js
@@ -100,7 +100,7 @@ var EBMLReader = (function (_super) {
             if (this.segmentOffset != 0) {
                 console.warn("Multiple segments detected!");
             }
-            this.segmentOffset = elm.tagEnd + 1;
+            this.segmentOffset = elm.dataStart;
             this.emit("segment_offset", this.segmentOffset);
         }
         else if (elm.type === "b" && elm.name === "SimpleBlock") {

--- a/lib/EBMLReader.js
+++ b/lib/EBMLReader.js
@@ -24,6 +24,7 @@ var EBMLReader = (function (_super) {
         _this.metadataloaded = false;
         _this.chunks = [];
         _this.stack = [];
+        _this.segmentOffset = 0;
         _this.lastSimpleBlockVideoTrackTimecode = 0;
         _this.lastClusterTimecode = 0;
         _this.lastClusterPosition = 0;
@@ -95,7 +96,14 @@ var EBMLReader = (function (_super) {
                 this.stack.push(elm);
             }
         }
-        if (elm.type === "b" && elm.name === "SimpleBlock") {
+        if (elm.type === "m" && elm.name == "Segment") {
+            if (this.segmentOffset != 0) {
+                console.warn("Multiple segments detected!");
+            }
+            this.segmentOffset = elm.tagEnd + 1;
+            this.emit("segment_offset", this.segmentOffset);
+        }
+        else if (elm.type === "b" && elm.name === "SimpleBlock") {
             var _a = tools.ebmlBlock(elm.data), timecode = _a.timecode, trackNumber = _a.trackNumber, frames_1 = _a.frames;
             if (this.trackTypes[trackNumber] === 1) {
                 // https://bugs.chromium.org/p/chromium/issues/detail?id=606000#c22

--- a/lib/tools.d.ts
+++ b/lib/tools.d.ts
@@ -29,11 +29,12 @@ export declare function VP8BitStreamToRiffWebPBuffer(frame: Buffer): Buffer;
 export declare function createRIFFChunk(FourCC: string, chunk: Buffer): Buffer;
 /**
  * metadata に対して duration と seekhead を追加した metadata を返す
+ * @param segmentOffset - the offset that needs to be applied to create relative offsets into a segement from abolsute offsets
  * @param metadata - 変更前の webm における ファイル先頭から 最初の Cluster 要素までの 要素
  * @param clusterPtrs - 変更前の webm における SeekHead に追加する Cluster 要素 への start pointer
  * @param duration - Duration に記載する値
  */
-export declare function putRefinedMetaData(metadata: EBML.EBMLElementDetail[], clusterPtrs: number[], duration: number, cueInfos?: {
+export declare function putRefinedMetaData(segmentOffset: number, metadata: EBML.EBMLElementDetail[], clusterPtrs: number[], duration: number, cueInfos?: {
     CueTrack: number;
     CueClusterPosition: number;
     CueTime: number;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -78,11 +78,12 @@ function createRIFFChunk(FourCC, chunk) {
 exports.createRIFFChunk = createRIFFChunk;
 /**
  * metadata に対して duration と seekhead を追加した metadata を返す
+ * @param segmentOffset - the offset that needs to be applied to create relative offsets into a segement from abolsute offsets
  * @param metadata - 変更前の webm における ファイル先頭から 最初の Cluster 要素までの 要素
  * @param clusterPtrs - 変更前の webm における SeekHead に追加する Cluster 要素 への start pointer
  * @param duration - Duration に記載する値
  */
-function putRefinedMetaData(metadata, clusterPtrs, duration, cueInfos) {
+function putRefinedMetaData(segmentOffset, metadata, clusterPtrs, duration, cueInfos) {
     var lastmetadata = metadata[metadata.length - 1];
     if (lastmetadata == null) {
         throw new Error("metadata not found");
@@ -93,11 +94,31 @@ function putRefinedMetaData(metadata, clusterPtrs, duration, cueInfos) {
     var metadataSize = lastmetadata.dataEnd; // 書き換える前の metadata のサイズ
     var encorder = new EBMLEncoder_1.default();
     // 一旦 seekhead を作って自身のサイズを調べる
-    var bufs = refineMetadata(0).reduce(function (lst, elm) { return lst.concat(encorder.encode([elm])); }, []);
-    var totalByte = bufs.reduce(function (o, buf) { return o + buf.byteLength; }, 0);
+    var refinedMetadata = refineMetadata(-segmentOffset);
+    var refinedMetadataSize = encodedSizeOfEbml(refinedMetadata);
     // 自分自身のサイズを考慮した seekhead を再構成する
     //console.log("sizeDiff", totalByte - metadataSize);
-    return refineMetadata(totalByte - metadataSize);
+    // We need the size to be stable between two refinements in order for our offsets to be correct
+    // Bound the number of possible refinements so we can't go infinate if something goes wrong
+    var i;
+    for (i = 1; i < 20; i++) {
+        var sizeDiff = refinedMetadataSize - metadataSize;
+        var newRefinedMetadata = refineMetadata(sizeDiff - segmentOffset);
+        var newRefinedMetadataSize = encodedSizeOfEbml(newRefinedMetadata);
+        if (newRefinedMetadataSize == refinedMetadataSize) {
+            // Size is stable
+            return newRefinedMetadata;
+        }
+        else {
+            refinedMetadata = newRefinedMetadata;
+            refinedMetadataSize = newRefinedMetadataSize;
+        }
+    }
+    throw new Error("unable to refine metadata, stable size could not be found in " + i + " iterations!");
+    // Given a list of EBMLElementBuffers, returns their encoded size in bytes
+    function encodedSizeOfEbml(refinedMetaData) {
+        return refinedMetaData.reduce(function (lst, elm) { return lst.concat(encorder.encode([elm])); }, []).reduce(function (o, buf) { return o + buf.byteLength; }, 0);
+    }
     function refineMetadata(sizeDiff) {
         if (sizeDiff === void 0) { sizeDiff = 0; }
         var _metadata = metadata.slice(0);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -92,7 +92,6 @@ function putRefinedMetaData(segmentOffset, metadata, clusterPtrs, duration, cueI
         throw new Error("metadata does not have size");
     } // metadata が 不定サイズ
     var metadataSize = lastmetadata.dataEnd; // 書き換える前の metadata のサイズ
-    var encorder = new EBMLEncoder_1.default();
     // 一旦 seekhead を作って自身のサイズを調べる
     var refinedMetadata = refineMetadata(-segmentOffset);
     var refinedMetadataSize = encodedSizeOfEbml(refinedMetadata);
@@ -117,6 +116,7 @@ function putRefinedMetaData(segmentOffset, metadata, clusterPtrs, duration, cueI
     throw new Error("unable to refine metadata, stable size could not be found in " + i + " iterations!");
     // Given a list of EBMLElementBuffers, returns their encoded size in bytes
     function encodedSizeOfEbml(refinedMetaData) {
+        var encorder = new EBMLEncoder_1.default();
         return refinedMetaData.reduce(function (lst, elm) { return lst.concat(encorder.encode([elm])); }, []).reduce(function (o, buf) { return o + buf.byteLength; }, 0);
     }
     function refineMetadata(sizeDiff) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -118,7 +118,7 @@ function putRefinedMetaData(metadata, clusterPtrs, duration, cueInfos) {
             insertTag(_metadata, "SeekHead", create_seek(clusterPtrs, sizeDiff));
         }
         if (Array.isArray(cueInfos)) {
-            insertTag(_metadata, "Que", create_que(cueInfos, sizeDiff));
+            insertTag(_metadata, "Cues", create_cue(cueInfos, sizeDiff));
         }
         return _metadata;
     }
@@ -135,19 +135,19 @@ function create_seek(clusterPtrs, sizeDiff) {
     });
     return seeks;
 }
-function create_que(cueInfos, sizeDiff) {
-    var ques = [];
+function create_cue(cueInfos, sizeDiff) {
+    var cues = [];
     cueInfos.forEach(function (_a) {
         var CueTrack = _a.CueTrack, CueClusterPosition = _a.CueClusterPosition, CueTime = _a.CueTime;
-        ques.push({ name: "CuePoint", type: "m", isEnd: false });
-        ques.push({ name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
-        ques.push({ name: "CueTrackPositions", type: "m", isEnd: false });
-        ques.push({ name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) }); // video track
-        ques.push({ name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition + sizeDiff) });
-        ques.push({ name: "CueTrackPositions", type: "m", isEnd: true });
-        ques.push({ name: "CuePoint", type: "m", isEnd: true });
+        cues.push({ name: "CuePoint", type: "m", isEnd: false });
+        cues.push({ name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
+        cues.push({ name: "CueTrackPositions", type: "m", isEnd: false });
+        cues.push({ name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) }); // video track
+        cues.push({ name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition + sizeDiff) });
+        cues.push({ name: "CueTrackPositions", type: "m", isEnd: true });
+        cues.push({ name: "CuePoint", type: "m", isEnd: true });
     });
-    return ques;
+    return cues;
 }
 function insertTag(_metadata, tagName, children) {
     var idx = -1;

--- a/src/EBMLReader.ts
+++ b/src/EBMLReader.ts
@@ -14,6 +14,7 @@ export default class EBMLReader extends EventEmitter {
   private stack: (EBML.MasterElement & EBML.ElementDetail)[];
   private chunks: EBML.EBMLElementBufferValue[];
 
+  private segmentOffset: number;
   private lastSimpleBlockVideoTrackTimecode: number;
   private lastClusterTimecode: number;
   private lastClusterPosition: number;
@@ -41,6 +42,7 @@ export default class EBMLReader extends EventEmitter {
     this.chunks = [];
     
     this.stack = [];
+    this.segmentOffset = 0;
     this.lastSimpleBlockVideoTrackTimecode = 0;
     this.lastClusterTimecode = 0;
     this.lastClusterPosition = 0;
@@ -111,7 +113,13 @@ export default class EBMLReader extends EventEmitter {
         this.stack.push(elm);
       }
     }
-    if(elm.type === "b" && elm.name === "SimpleBlock"){
+    if(elm.type === "m" && elm.name == "Segment"){
+      if(this.segmentOffset != 0) {
+        console.warn("Multiple segments detected!");
+      }
+      this.segmentOffset = elm.tagEnd + 1;
+      this.emit("segment_offset", this.segmentOffset);
+    }else if(elm.type === "b" && elm.name === "SimpleBlock"){
       const {timecode, trackNumber, frames} = tools.ebmlBlock(elm.data);
       if(this.trackTypes[trackNumber] === 1){ // trackType === 1 => video track
         // https://bugs.chromium.org/p/chromium/issues/detail?id=606000#c22
@@ -192,6 +200,8 @@ export default class EBMLReader extends EventEmitter {
     const duration = duration_nanosec / this.timecodeScale;
     return Math.floor(duration);
   }
+  /** emit on every segment **/
+  addListener(event: "segment_offset", listener: (ev: number )=> void): this;
   /** emit on every cluster element start */
   addListener(event: "cluster_ptr", listener: (ev: number )=> void): this;
   /** emit on every cue point */

--- a/src/EBMLReader.ts
+++ b/src/EBMLReader.ts
@@ -117,7 +117,7 @@ export default class EBMLReader extends EventEmitter {
       if(this.segmentOffset != 0) {
         console.warn("Multiple segments detected!");
       }
-      this.segmentOffset = elm.tagEnd + 1;
+      this.segmentOffset = elm.dataStart;
       this.emit("segment_offset", this.segmentOffset);
     }else if(elm.type === "b" && elm.name === "SimpleBlock"){
       const {timecode, trackNumber, frames} = tools.ebmlBlock(elm.data);

--- a/src/example_seekable.ts
+++ b/src/example_seekable.ts
@@ -8,6 +8,7 @@ async function main() {
   reader.logging = true;
 
   let tasks = Promise.resolve(void 0);
+  let segmentOffset = 0;
   let metadataElms: EBML.EBMLElementDetail[] = [];
   let metadataSize = 0;
   let webM = new Blob([], {type: "video/webm"});
@@ -18,6 +19,10 @@ async function main() {
 
   const stream = await navigator.mediaDevices.getUserMedia({video: true, audio: true});
   const rec = new MediaRecorder(stream, { mimeType: 'video/webm; codecs="vp8, opus"'});
+
+  reader.addListener("segment_offset", (offset)=>{
+    segmentOffset = offset;
+  });
 
   reader.addListener("metadata", ({data, metadataSize: size})=>{
       metadataElms = data;
@@ -32,7 +37,7 @@ async function main() {
     cluster_ptrs.push(ptr);
   });
 
-  reader.addListener("cue_info", ({CueTrack, CueClusterPosition, CueTime}) =>{
+  reader.addListener("cue_info", ({CueTrack, CueClusterPosition, CueTime})=>{
     cue_points.push({CueTrack, CueClusterPosition, CueTime});
   })
 
@@ -56,7 +61,7 @@ async function main() {
   rec.stream.getTracks().map((track) => { track.stop(); });
   reader.stop();
 
-  const refinedMetadataElms = tools.putRefinedMetaData(metadataElms, cluster_ptrs, last_duration, cue_points);
+  const refinedMetadataElms = tools.putRefinedMetaData(segmentOffset, metadataElms, cluster_ptrs, last_duration, cue_points);
   const refinedMetadataBuf = new Encoder().encode(refinedMetadataElms);
   const webMBuf = await readAsArrayBuffer(webM);
   const body = webMBuf.slice(metadataSize);

--- a/src/test.ts
+++ b/src/test.ts
@@ -140,10 +140,16 @@ function convert_to_seekable_test(file: string){
     const reader = new EBMLReader();
     reader.logging = true;
 
+    let segmentOffset = 0;
     let metadataElms: EBML.EBMLElementDetail[] = [];
     let metadataSize = 0;
     let last_duration = 0;
     const cluster_ptrs: number[] = [];
+
+    reader.addListener("segment_offset", (offset)=>{
+      assert.ok(offset > 0);
+      segmentOffset = offset;
+    });
 
     reader.addListener("metadata", ({data, metadataSize: size})=>{
       assert.ok(data.length > 0, "metadata.length:"+data.length);
@@ -185,7 +191,7 @@ function convert_to_seekable_test(file: string){
 
     console.info("convert to seekable file");
 
-    const refinedMetadataElms = tools.putRefinedMetaData(metadataElms, cluster_ptrs, last_duration);
+    const refinedMetadataElms = tools.putRefinedMetaData(segmentOffset, metadataElms, cluster_ptrs, last_duration);
     const refinedMetadataBuf = new Encoder().encode(refinedMetadataElms);
     const body = webm_buf.slice(metadataSize);
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -116,7 +116,7 @@ export function putRefinedMetaData(
       insertTag(_metadata, "SeekHead", create_seek(clusterPtrs, sizeDiff));
     }
     if(Array.isArray(cueInfos)){
-      insertTag(_metadata, "Que", create_que(cueInfos, sizeDiff));
+      insertTag(_metadata, "Cues", create_cue(cueInfos, sizeDiff));
     }
     return _metadata;
   }
@@ -132,18 +132,18 @@ function create_seek(clusterPtrs: number[], sizeDiff: number): EBML.EBMLElementB
   });
   return seeks;
 }
-function create_que(cueInfos: {CueTrack: number; CueClusterPosition: number; CueTime: number; }[], sizeDiff: number): EBML.EBMLElementBuffer[] {
-  const ques: EBML.EBMLElementBuffer[] = [];
+function create_cue(cueInfos: {CueTrack: number; CueClusterPosition: number; CueTime: number; }[], sizeDiff: number): EBML.EBMLElementBuffer[] {
+  const cues: EBML.EBMLElementBuffer[] = [];
   cueInfos.forEach(({CueTrack, CueClusterPosition, CueTime})=>{
-    ques.push({name: "CuePoint", type: "m", isEnd: false});
-      ques.push({name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
-      ques.push({name: "CueTrackPositions", type: "m", isEnd: false});
-        ques.push({name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) }); // video track
-        ques.push({name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition +  sizeDiff) });
-      ques.push({name: "CueTrackPositions", type: "m", isEnd: true});
-    ques.push({name: "CuePoint", type: "m", isEnd: true});
+    cues.push({name: "CuePoint", type: "m", isEnd: false});
+      cues.push({name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
+      cues.push({name: "CueTrackPositions", type: "m", isEnd: false});
+        cues.push({name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) }); // video track
+        cues.push({name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition +  sizeDiff) });
+      cues.push({name: "CueTrackPositions", type: "m", isEnd: true});
+    cues.push({name: "CuePoint", type: "m", isEnd: true});
   });
-  return ques;
+  return cues;
 }
 
 export function insertTag(_metadata: EBML.EBMLElementBuffer[], tagName: string, children: EBML.EBMLElementBuffer[]): void {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -91,7 +91,6 @@ export function putRefinedMetaData(
   if(lastmetadata == null){ throw new Error("metadata not found"); }
   if(lastmetadata.dataEnd < 0){ throw new Error("metadata does not have size"); } // metadata が 不定サイズ
   const metadataSize = lastmetadata.dataEnd; // 書き換える前の metadata のサイズ
-  const encorder = new Encoder();
   // 一旦 seekhead を作って自身のサイズを調べる
   let refinedMetadata = refineMetadata(-segmentOffset);
   let refinedMetadataSize = encodedSizeOfEbml(refinedMetadata);
@@ -117,6 +116,7 @@ export function putRefinedMetaData(
 
   // Given a list of EBMLElementBuffers, returns their encoded size in bytes
   function encodedSizeOfEbml(refinedMetaData: EBML.EBMLElementBuffer[]): number {
+    const encorder = new Encoder();
     return refinedMetaData.reduce<ArrayBuffer[]>((lst, elm)=> lst.concat(encorder.encode([elm])), []).reduce((o, buf)=> o + buf.byteLength, 0);
   }
 


### PR DESCRIPTION
This PR improves upon the existing handling of metadata refinement in the following ways:

- Corrects issues preventing the writing of cues
- Updates handling of offsets so they are relative into segments, as per the [spec](https://www.matroska.org/technical/specs/notes.html#Position_References)
- Ensures metadata is rewritten again if the size is unstable. That is to say, that it's possible when calculating the size of the metadata and offsets for the varints storing the offsets to grow in size. requiring another calculation of the header. This could happen an arbitrary number of times based on how many offsets you have, but in practice should be rare, so the code to do so has a hard coded bound (20) and throws an error if it fails
- Updates examples to reflect the above