### PR TITLE
New metadata refine method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/lib/EBMLReader.d.ts
+++ b/lib/EBMLReader.d.ts
@@ -31,6 +31,8 @@ export default class EBMLReader extends EventEmitter {
     use_webp: boolean;
     use_duration_every_simpleblock: boolean;
     logging: boolean;
+    logGroup: string;
+    private hasLoggingStarted;
     /**
      * usefull for recording chunks.
      */
@@ -93,6 +95,7 @@ export default class EBMLReader extends EventEmitter {
     }) => void): this;
     /** for thumbnail */
     addListener(event: "webp", listener: (ev: ThumbnailInfo) => void): this;
+    put(elm: EBML.EBMLElementDetail): void;
 }
 /** CueClusterPosition: Offset byte from __file start__. It is not an offset from the Segment element. */
 export interface CueInfo {
@@ -111,4 +114,3 @@ export interface ThumbnailInfo {
     webp: Blob;
     currentTime: number;
 }
-export declare function put(elm: EBML.EBMLElementDetail): void;

--- a/lib/EBMLReader.js
+++ b/lib/EBMLReader.js
@@ -21,6 +21,8 @@ var EBMLReader = (function (_super) {
     __extends(EBMLReader, _super);
     function EBMLReader() {
         var _this = _super.call(this) || this;
+        _this.logGroup = "";
+        _this.hasLoggingStarted = false;
         _this.metadataloaded = false;
         _this.chunks = [];
         _this.stack = [];
@@ -52,11 +54,16 @@ var EBMLReader = (function (_super) {
     EBMLReader.prototype.stop = function () {
         this.ended = true;
         this.emit_segment_info();
-        if (this.logging) {
-            // Valid only for chrome
-            console.groupEnd(); // </Cluster>
-            console.groupEnd(); // </Segment>
-            console.groupEnd(); // ?
+        // clean up any unclosed Master Elements at the end of the stream.
+        while (this.stack.length) {
+            this.stack.pop();
+            if (this.logging) {
+                console.groupEnd();
+            }
+        }
+        // close main group if set, logging is enabled, and has actually logged anything.
+        if (this.logging && this.hasLoggingStarted && this.logGroup) {
+            console.groupEnd();
         }
     };
     /**
@@ -98,6 +105,11 @@ var EBMLReader = (function (_super) {
                 if (parent_1 != null && parent_1.level >= elm.level) {
                     // 閉じタグなしでレベルが下がったら閉じタグを挿入
                     this.stack.pop();
+                    // From http://w3c.github.io/media-source/webm-byte-stream-format.html#webm-media-segments
+                    // This fixes logging for webm streams with Cluster of unknown length and no Cluster closing elements.
+                    if (this.logging) {
+                        console.groupEnd();
+                    }
                     parent_1.dataEnd = elm.dataEnd;
                     parent_1.dataSize = elm.dataEnd - parent_1.dataStart;
                     parent_1.unknownSize = false;
@@ -200,7 +212,7 @@ var EBMLReader = (function (_super) {
             this.chunks.push(elm);
         }
         if (this.logging) {
-            put(elm);
+            this.put(elm);
         }
     };
     Object.defineProperty(EBMLReader.prototype, "duration", {
@@ -269,6 +281,34 @@ var EBMLReader = (function (_super) {
     EBMLReader.prototype.addListener = function (event, listener) {
         return _super.prototype.addListener.call(this, event, listener);
     };
+    EBMLReader.prototype.put = function (elm) {
+        if (!this.hasLoggingStarted) {
+            this.hasLoggingStarted = true;
+            if (this.logging && this.logGroup) {
+                console.groupCollapsed(this.logGroup);
+            }
+        }
+        if (elm.type === "m") {
+            if (elm.isEnd) {
+                console.groupEnd();
+            }
+            else {
+                console.group(elm.name + ":" + elm.tagStart);
+            }
+        }
+        else if (elm.type === "b") {
+            // for debug
+            //if(elm.name === "SimpleBlock"){
+            //const o = EBML.tools.ebmlBlock(elm.value);
+            //console.log(elm.name, elm.type, o.trackNumber, o.timecode);
+            //}else{
+            console.log(elm.name, elm.type);
+            //}
+        }
+        else {
+            console.log(elm.name, elm.tagStart, elm.type, elm.value);
+        }
+    };
     return EBMLReader;
 }(events_1.EventEmitter));
 exports.default = EBMLReader;
@@ -276,26 +316,3 @@ exports.default = EBMLReader;
 ;
 ;
 ;
-function put(elm) {
-    if (elm.type === "m") {
-        if (elm.isEnd) {
-            console.groupEnd();
-        }
-        else {
-            console.group(elm.name + ":" + elm.tagStart);
-        }
-    }
-    else if (elm.type === "b") {
-        // for debug
-        //if(elm.name === "SimpleBlock"){
-        //const o = EBML.tools.ebmlBlock(elm.value);
-        //console.log(elm.name, elm.type, o.trackNumber, o.timecode);
-        //}else{
-        console.log(elm.name, elm.type);
-        //}
-    }
-    else {
-        console.log(elm.name, elm.tagStart, elm.type, elm.value);
-    }
-}
-exports.put = put;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,7 +26,7 @@ if (com.seekable) {
     var elms = decoder.decode(buf);
     elms.forEach(function (elm) { reader_1.read(elm); });
     reader_1.stop();
-    var refinedMetadataBuf = _1.tools.putRefinedMetaData(reader_1.metadatas, reader_1);
+    var refinedMetadataBuf = _1.tools.makeMetadataSeekable(reader_1.metadatas, reader_1.duration, reader_1.cues);
     var body = buf.slice(reader_1.metadataSize);
     var refined = new Buffer(_1.tools.concat([new Buffer(refinedMetadataBuf), body]).buffer);
     process.stdout.write(refined);

--- a/lib/tools.d.ts
+++ b/lib/tools.d.ts
@@ -32,6 +32,46 @@ export declare function VP8BitStreamToRiffWebPBuffer(frame: Buffer): Buffer;
  */
 export declare function createRIFFChunk(FourCC: string, chunk: Buffer): Buffer;
 /**
+ * convert the metadata from a streaming webm bytestream to a seekable file by inserting Duration, Seekhead and Cues
+ * @param originalMetadata - orginal metadata (everything before the clusters start) from media recorder
+ * @param duration - Duration (TimecodeScale)
+ * @param cues - cue points for clusters
+ */
+export declare function makeMetadataSeekable(originalMetadata: EBML.EBMLElementDetail[], duration: number, cuesInfo: {
+    CueTrack: number;
+    CueClusterPosition: number;
+    CueTime: number;
+}[]): ArrayBuffer;
+/**
+ * print all element id names in a list
+
+ * @param metadata - array of EBML elements to print
+ *
+export function printElementIds(metadata: EBML.EBMLElementBuffer[]) {
+
+  let result: EBML.EBMLElementBuffer[] = [];
+  let start: number = -1;
+
+  for (let i = 0; i < metadata.length; i++) {
+    console.error("\t id: " + metadata[i].name);
+  }
+}
+*/
+/**
+ * remove all occurances of an EBML element from an array of elements
+ * If it's a MasterElement you will also remove the content. (everything between start and end)
+ * @param idName - name of the EBML Element to remove.
+ * @param metadata - array of EBML elements to search
+ */
+export declare function removeElement(idName: string, metadata: EBML.EBMLElementBuffer[]): void;
+/**
+ * extract the first occurance of an EBML tag from a flattened array of EBML data.
+ * If it's a MasterElement you will also get the content. (everything between start and end)
+ * @param idName - name of the EBML Element to extract.
+ * @param metadata - array of EBML elements to search
+ */
+export declare function extractElement(idName: string, metadata: EBML.EBMLElementBuffer[]): EBML.EBMLElementBuffer[];
+/**
  * metadata に対して duration と seekhead を追加した metadata を返す
  * @param metadata - 変更前の webm における ファイル先頭から 最初の Cluster 要素までの 要素
  * @param duration - Duration (TimecodeScale)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -90,6 +90,312 @@ function createRIFFChunk(FourCC, chunk) {
     ]);
 }
 exports.createRIFFChunk = createRIFFChunk;
+/* Original Metadata
+
+ m  0	EBML
+ u  1	  EBMLVersion 1
+ u  1	  EBMLReadVersion 1
+ u  1	  EBMLMaxIDLength 4
+ u  1	  EBMLMaxSizeLength 8
+ s  1	  DocType webm
+ u  1	  DocTypeVersion 4
+ u  1	  DocTypeReadVersion 2
+ m  0	Segment
+ m  1	  Info                                segmentContentStartPos, all CueClusterPositions provided in info.cues will be relative to here and will need adjusted
+ u  2	    TimecodeScale 1000000
+ 8  2	    MuxingApp Chrome
+ 8  2	    WritingApp Chrome
+ m  1	  Tracks                              tracksStartPos
+ m  2	    TrackEntry
+ u  3	      TrackNumber 1
+ u  3	      TrackUID 31790271978391090
+ u  3	      TrackType 2
+ s  3	      CodecID A_OPUS
+ b  3	      CodecPrivate <Buffer 19>
+ m  3	      Audio
+ f  4	        SamplingFrequency 48000
+ u  4	        Channels 1
+ m  2	    TrackEntry
+ u  3	      TrackNumber 2
+ u  3	      TrackUID 24051277436254136
+ u  3	      TrackType 1
+ s  3	      CodecID V_VP8
+ m  3	      Video
+ u  4	        PixelWidth 1024
+ u  4	        PixelHeight 576
+ m  1	  Cluster                             clusterStartPos
+ u  2	    Timecode 0
+ b  2	    SimpleBlock track:2 timecode:0	keyframe:true	invisible:false	discardable:false	lacing:1
+*/
+/* Desired Metadata
+
+ m	0 EBML
+ u	1   EBMLVersion 1
+ u	1   EBMLReadVersion 1
+ u	1   EBMLMaxIDLength 4
+ u	1   EBMLMaxSizeLength 8
+ s	1   DocType webm
+ u	1   DocTypeVersion 4
+ u	1   DocTypeReadVersion 2
+ m	0 Segment
+ m	1   SeekHead                            -> This is SeekPosition 0, so all SeekPositions can be calculated as (bytePos - segmentContentStartPos), which is 44 in this case
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x15, 0x49, 0xA9, 0x66])  Info
+ u	3       SeekPosition                    -> infoStartPos =
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x16, 0x54, 0xAE, 0x6B])  Tracks
+ u	3       SeekPosition { tracksStartPos }
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x1C, 0x53, 0xBB, 0x6B])  Cues
+ u	3       SeekPosition { cuesStartPos }
+ m	1   Info
+ f	2     Duration 32480                    -> overwrite, or insert if it doesn't exist
+ u	2     TimecodeScale 1000000
+ 8	2     MuxingApp Chrome
+ 8	2     WritingApp Chrome
+ m	1   Tracks
+ m	2     TrackEntry
+ u	3       TrackNumber 1
+ u	3       TrackUID 31790271978391090
+ u	3       TrackType 2
+ s	3       CodecID A_OPUS
+ b	3       CodecPrivate <Buffer 19>
+ m	3       Audio
+ f	4         SamplingFrequency 48000
+ u	4         Channels 1
+ m	2     TrackEntry
+ u	3       TrackNumber 2
+ u	3       TrackUID 24051277436254136
+ u	3       TrackType 1
+ s	3       CodecID V_VP8
+ m	3       Video
+ u	4         PixelWidth 1024
+ u	4         PixelHeight 576
+ m  1   Cues                                -> cuesStartPos
+ m  2     CuePoint
+ u  3       CueTime 0
+ m  3       CueTrackPositions
+ u  4         CueTrack 1
+ u  4         CueClusterPosition 3911
+ m  2     CuePoint
+ u  3       CueTime 600
+ m  3       CueTrackPositions
+ u  4         CueTrack 1
+ u  4         CueClusterPosition 3911
+ m  1   Cluster
+ u  2     Timecode 0
+ b  2     SimpleBlock track:2 timecode:0	keyframe:true	invisible:false	discardable:false	lacing:1
+*/
+/**
+ * convert the metadata from a streaming webm bytestream to a seekable file by inserting Duration, Seekhead and Cues
+ * @param originalMetadata - orginal metadata (everything before the clusters start) from media recorder
+ * @param duration - Duration (TimecodeScale)
+ * @param cues - cue points for clusters
+ */
+function makeMetadataSeekable(originalMetadata, duration, cuesInfo) {
+    // extract the header, we can reuse this as-is
+    var header = extractElement("EBML", originalMetadata);
+    var headerSize = encodedSizeOfEbml(header);
+    //console.error("Header size: " + headerSize);
+    //printElementIds(header);
+    // After the header comes the Segment open tag, which in this implementation is always 12 bytes (4 byte id, 8 byte 'unknown length')
+    // After that the segment content starts. All SeekPositions and CueClusterPosition must be relative to segmentContentStartPos
+    var segmentContentStartPos = headerSize + 12;
+    //console.error("segmentContentStartPos: " + segmentContentStartPos);    
+    // find the original metadata size, and adjust it for header size and Segment start element so we can keep all positions relative to segmentContentStartPos
+    var originalMetadataSize = originalMetadata[originalMetadata.length - 1].dataEnd - segmentContentStartPos;
+    //console.error("Original Metadata size: " + originalMetadataSize);
+    //printElementIds(originalMetadata);
+    // extract the segment info, remove the potentially existing Duration element, and add our own one.
+    var info = extractElement("Info", originalMetadata);
+    removeElement("Duration", info);
+    info.splice(1, 0, { name: "Duration", type: "f", data: createFloatBuffer(duration, 8) });
+    var infoSize = encodedSizeOfEbml(info);
+    //console.error("Info size: " + infoSize);
+    //printElementIds(info);  
+    // extract the track info, we can re-use this as is
+    var tracks = extractElement("Tracks", originalMetadata);
+    var tracksSize = encodedSizeOfEbml(tracks);
+    //console.error("Tracks size: " + tracksSize);
+    //printElementIds(tracks);  
+    var seekHeadSize = 47; // Initial best guess, but could be slightly larger if the Cues element is huge.
+    var seekHead = [];
+    var cuesSize = 5 + cuesInfo.length * 15; // very rough initial approximation, depends a lot on file size and number of CuePoints                   
+    var cues = [];
+    var lastSizeDifference = -1; // 
+    // The size of SeekHead and Cues elements depends on how many bytes the offsets values can be encoded in.
+    // The actual offsets in CueClusterPosition depend on the final size of the SeekHead and Cues elements
+    // We need to iteratively converge to a stable solution.
+    var maxIterations = 10;
+    var _loop_1 = function (i) {
+        // SeekHead starts at 0
+        var infoStart = seekHeadSize; // Info comes directly after SeekHead
+        var tracksStart = infoStart + infoSize; // Tracks comes directly after Info
+        var cuesStart = tracksStart + tracksSize; // Cues starts directly after 
+        var newMetadataSize = cuesStart + cuesSize; // total size of metadata  
+        // This is the offset all CueClusterPositions should be adjusted by due to the metadata size changing.
+        var sizeDifference = newMetadataSize - originalMetadataSize;
+        // console.error(`infoStart: ${infoStart}, infoSize: ${infoSize}`);
+        // console.error(`tracksStart: ${tracksStart}, tracksSize: ${tracksSize}`);
+        // console.error(`cuesStart: ${cuesStart}, cuesSize: ${cuesSize}`);
+        // console.error(`originalMetadataSize: ${originalMetadataSize}, newMetadataSize: ${newMetadataSize}, sizeDifference: ${sizeDifference}`); 
+        // create the SeekHead element
+        seekHead = [];
+        seekHead.push({ name: "SeekHead", type: "m", isEnd: false });
+        seekHead.push({ name: "Seek", type: "m", isEnd: false });
+        seekHead.push({ name: "SeekID", type: "b", data: new exports.Buffer([0x15, 0x49, 0xA9, 0x66]) }); // Info
+        seekHead.push({ name: "SeekPosition", type: "u", data: createUIntBuffer(infoStart) });
+        seekHead.push({ name: "Seek", type: "m", isEnd: true });
+        seekHead.push({ name: "Seek", type: "m", isEnd: false });
+        seekHead.push({ name: "SeekID", type: "b", data: new exports.Buffer([0x16, 0x54, 0xAE, 0x6B]) }); // Tracks
+        seekHead.push({ name: "SeekPosition", type: "u", data: createUIntBuffer(tracksStart) });
+        seekHead.push({ name: "Seek", type: "m", isEnd: true });
+        seekHead.push({ name: "Seek", type: "m", isEnd: false });
+        seekHead.push({ name: "SeekID", type: "b", data: new exports.Buffer([0x1C, 0x53, 0xBB, 0x6B]) }); // Cues
+        seekHead.push({ name: "SeekPosition", type: "u", data: createUIntBuffer(cuesStart) });
+        seekHead.push({ name: "Seek", type: "m", isEnd: true });
+        seekHead.push({ name: "SeekHead", type: "m", isEnd: true });
+        seekHeadSize = encodedSizeOfEbml(seekHead);
+        //console.error("SeekHead size: " + seekHeadSize);
+        //printElementIds(seekHead);  
+        // create the Cues element
+        cues = [];
+        cues.push({ name: "Cues", type: "m", isEnd: false });
+        cuesInfo.forEach(function (_a) {
+            var CueTrack = _a.CueTrack, CueClusterPosition = _a.CueClusterPosition, CueTime = _a.CueTime;
+            cues.push({ name: "CuePoint", type: "m", isEnd: false });
+            cues.push({ name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
+            cues.push({ name: "CueTrackPositions", type: "m", isEnd: false });
+            cues.push({ name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) });
+            //console.error(`CueClusterPosition: ${CueClusterPosition}, Corrected to: ${CueClusterPosition - segmentContentStartPos}  , offset by ${sizeDifference} to become ${(CueClusterPosition - segmentContentStartPos) + sizeDifference - segmentContentStartPos}`);
+            // EBMLReader returns CueClusterPosition with absolute byte offsets. The Cues section expects them as offsets from the first level 1 element of the Segment, so we need to adjust it.
+            CueClusterPosition -= segmentContentStartPos;
+            // We also need to adjust to take into account the change in metadata size from when EBMLReader read the original metadata.
+            CueClusterPosition += sizeDifference;
+            cues.push({ name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition) });
+            cues.push({ name: "CueTrackPositions", type: "m", isEnd: true });
+            cues.push({ name: "CuePoint", type: "m", isEnd: true });
+        });
+        cues.push({ name: "Cues", type: "m", isEnd: true });
+        cuesSize = encodedSizeOfEbml(cues);
+        //console.error("Cues size: " + cuesSize);   
+        //console.error("Cue count: " + cuesInfo.length);
+        //printElementIds(cues);      
+        // If the new MetadataSize is not the same as the previous iteration, we need to run once more.
+        if (lastSizeDifference !== sizeDifference) {
+            lastSizeDifference = sizeDifference;
+            if (i === maxIterations - 1) {
+                throw new Error("Failed to converge to a stable metadata size");
+            }
+        }
+        else {
+            return "break";
+        }
+    };
+    for (var i = 0; i < maxIterations; i++) {
+        var state_1 = _loop_1(i);
+        if (state_1 === "break")
+            break;
+    }
+    var finalMetadata = [].concat.apply([], [
+        header,
+        { name: "Segment", type: "m", isEnd: false, unknownSize: true },
+        seekHead,
+        info,
+        tracks,
+        cues
+    ]);
+    var result = new EBMLEncoder_1.default().encode(finalMetadata);
+    //printElementIds(finalMetadata);
+    //console.error(`Final metadata buffer size: ${result.byteLength}`);
+    //console.error(`Final metadata buffer size without header and segment: ${result.byteLength-segmentContentStartPos}`);
+    return result;
+}
+exports.makeMetadataSeekable = makeMetadataSeekable;
+/**
+ * print all element id names in a list
+
+ * @param metadata - array of EBML elements to print
+ *
+export function printElementIds(metadata: EBML.EBMLElementBuffer[]) {
+
+  let result: EBML.EBMLElementBuffer[] = [];
+  let start: number = -1;
+
+  for (let i = 0; i < metadata.length; i++) {
+    console.error("\t id: " + metadata[i].name);
+  }
+}
+*/
+/**
+ * remove all occurances of an EBML element from an array of elements
+ * If it's a MasterElement you will also remove the content. (everything between start and end)
+ * @param idName - name of the EBML Element to remove.
+ * @param metadata - array of EBML elements to search
+ */
+function removeElement(idName, metadata) {
+    var result = [];
+    var start = -1;
+    for (var i = 0; i < metadata.length; i++) {
+        var element = metadata[i];
+        if (element.name === idName) {
+            // if it's a Master element, extract the start and end element, and everything in between
+            if (element.type === "m") {
+                if (!element.isEnd) {
+                    start = i;
+                }
+                else {
+                    // we've reached the end, extract the whole thing
+                    if (start == -1)
+                        throw new Error("Detected " + idName + " closing element before finding the start");
+                    metadata.splice(start, i - start + 1);
+                    return;
+                }
+            }
+            else {
+                // not a Master element, so we've found what we're looking for.
+                metadata.splice(i, 1);
+                return;
+            }
+        }
+    }
+}
+exports.removeElement = removeElement;
+/**
+ * extract the first occurance of an EBML tag from a flattened array of EBML data.
+ * If it's a MasterElement you will also get the content. (everything between start and end)
+ * @param idName - name of the EBML Element to extract.
+ * @param metadata - array of EBML elements to search
+ */
+function extractElement(idName, metadata) {
+    var result = [];
+    var start = -1;
+    for (var i = 0; i < metadata.length; i++) {
+        var element = metadata[i];
+        if (element.name === idName) {
+            // if it's a Master element, extract the start and end element, and everything in between
+            if (element.type === "m") {
+                if (!element.isEnd) {
+                    start = i;
+                }
+                else {
+                    // we've reached the end, extract the whole thing
+                    if (start == -1)
+                        throw new Error("Detected " + idName + " closing element before finding the start");
+                    result = metadata.slice(start, i + 1);
+                    break;
+                }
+            }
+            else {
+                // not a Master element, so we've found what we're looking for.
+                result.push(metadata[i]);
+                break;
+            }
+        }
+    }
+    return result;
+}
+exports.extractElement = extractElement;
 /**
  * metadata に対して duration と seekhead を追加した metadata を返す
  * @param metadata - 変更前の webm における ファイル先頭から 最初の Cluster 要素までの 要素

--- a/src/EBMLReader.ts
+++ b/src/EBMLReader.ts
@@ -39,6 +39,8 @@ export default class EBMLReader extends EventEmitter {
   use_webp: boolean;
   use_duration_every_simpleblock: boolean; // heavy
   logging: boolean;
+  logGroup: string = "";
+  private hasLoggingStarted: boolean = false;
   /**
    * usefull for recording chunks.
    */
@@ -73,6 +75,7 @@ export default class EBMLReader extends EventEmitter {
     this.ended = false;
 
     this.logging = false;
+
     this.use_duration_every_simpleblock = false;
     this.use_webp = false;
     this.use_segment_info = true;
@@ -92,6 +95,11 @@ export default class EBMLReader extends EventEmitter {
       if (this.logging) {
         console.groupEnd();
       }
+    }
+
+    // close main group if set, logging is enabled, and has actually logged anything.
+    if  (this.logging && this.hasLoggingStarted && this.logGroup) {
+      console.groupEnd();
     }
   }
 
@@ -219,7 +227,7 @@ export default class EBMLReader extends EventEmitter {
       this.metadataSize = elm.dataEnd;
     }
     if(!drop){ this.chunks.push(elm); }
-    if(this.logging){ put(elm); }
+    if(this.logging){ this.put(elm); }
   }
   /**
    * DefaultDuration が定義されている場合は最後のフレームのdurationも考慮する
@@ -304,32 +312,37 @@ export default class EBMLReader extends EventEmitter {
   addListener(event: string, listener: (ev: any)=> void): this {
     return super.addListener(event, listener);
   }
+
+  put(elm: EBML.EBMLElementDetail) {
+    if (!this.hasLoggingStarted) {
+      this.hasLoggingStarted = true;
+      if  (this.logging && this.logGroup) {
+        console.groupCollapsed(this.logGroup);
+      }
+    }
+    if(elm.type === "m"){
+      if(elm.isEnd){
+        console.groupEnd();
+      }else{
+        console.group(elm.name+":"+elm.tagStart);
+      }
+    }else if(elm.type === "b"){
+      // for debug
+      //if(elm.name === "SimpleBlock"){
+        //const o = EBML.tools.ebmlBlock(elm.value);
+        //console.log(elm.name, elm.type, o.trackNumber, o.timecode);
+      //}else{
+        console.log(elm.name, elm.type);
+      //}
+    }else{
+      console.log(elm.name, elm.tagStart, elm.type, elm.value);
+    }
+  }
 }
 /** CueClusterPosition: Offset byte from __file start__. It is not an offset from the Segment element. */
 export interface CueInfo {CueTrack: number; CueClusterPosition: number; CueTime: number; };
 export interface SegmentInfo {data: EBML.EBMLElementDetail[];};
 export interface DurationInfo {duration: number; timecodeScale: number;};
 export interface ThumbnailInfo {webp: Blob; currentTime: number;};
-
-
-export function put(elm: EBML.EBMLElementDetail){
-  if(elm.type === "m"){
-    if(elm.isEnd){
-      console.groupEnd();
-    }else{
-      console.group(elm.name+":"+elm.tagStart);
-    }
-  }else if(elm.type === "b"){
-    // for debug
-    //if(elm.name === "SimpleBlock"){
-      //const o = EBML.tools.ebmlBlock(elm.value);
-      //console.log(elm.name, elm.type, o.trackNumber, o.timecode);
-    //}else{
-      console.log(elm.name, elm.type);
-    //}
-  }else{
-    console.log(elm.name, elm.tagStart, elm.type, elm.value);
-  }
-}
 
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ if(com.seekable){
   const elms = decoder.decode(buf);
   elms.forEach((elm)=>{ reader.read(elm); });
   reader.stop();
-  const refinedMetadataBuf = tools.putRefinedMetaData(reader.metadatas, reader);
+  const refinedMetadataBuf = tools.makeMetadataSeekable(reader.metadatas, reader.duration, reader.cues);
   const body = buf.slice(reader.metadataSize);
   const refined = new Buffer(tools.concat([new Buffer(refinedMetadataBuf), body]).buffer);
   process.stdout.write(refined);

--- a/src/example_seekable.ts
+++ b/src/example_seekable.ts
@@ -116,7 +116,12 @@ async function main_from_recorder(duration: number, codec: string) {
   raw_video.src = URL.createObjectURL(webM);
   raw_video.controls = true;
 
+  const rawVideoButton = document.createElement("button");
+  rawVideoButton.textContent = "Download Raw Video";
+  rawVideoButton.addEventListener("click", () => { saveData(webM, "raw.webm") });  
   put(raw_video, "Raw WebM Stream (not seekable)");
+  document.body.appendChild(document.createElement("br"));
+  document.body.appendChild(rawVideoButton);
 
   const infos = [
     //{duration: reader.duration, title: "add duration only (seekable but slow)"},
@@ -140,7 +145,12 @@ async function main_from_recorder(duration: number, codec: string) {
     const refined_video = document.createElement("video");
     refined_video.src = URL.createObjectURL(refinedWebM);
     refined_video.controls = true;
+    const refinedVideoButton = document.createElement("button");
+    refinedVideoButton.textContent = "Download Refined Video";
+    refinedVideoButton.addEventListener("click", () => { saveData(refinedWebM, "refined.webm") });
     put(refined_video, info.title);
+    document.body.appendChild(document.createElement("br"));
+    document.body.appendChild(refinedVideoButton);
   }
 }
 
@@ -163,6 +173,19 @@ function readAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
 function sleep(ms: number): Promise<any>{
   return new Promise((resolve)=> setTimeout(resolve, ms) );
 }
+
+var saveData = (function () {
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.setAttribute("style", "display: none");
+    return function (blob, fileName) {
+        var url = window.URL.createObjectURL(blob);
+        a.href = url;
+        a.download = fileName;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    };
+}());
 
 // MediaRecorder API
 interface BlobEvent extends Event {

--- a/src/example_seekable.ts
+++ b/src/example_seekable.ts
@@ -16,7 +16,7 @@ async function main_from_file() {
   const elms = decoder.decode(webMBuf);
   elms.forEach((elm)=>{ reader.read(elm); });
   reader.stop();
-  const refinedMetadataBuf = tools.putRefinedMetaData(reader.metadatas, reader);
+  const refinedMetadataBuf = tools.makeMetadataSeekable(reader.metadatas, reader.duration, reader.cues);
   const body = webMBuf.slice(reader.metadataSize);
   const refinedWebM = new Blob([refinedMetadataBuf, body], {type: "video/webm"});
   const refined_video = document.createElement("video");
@@ -95,7 +95,7 @@ async function main_from_recorder() {
     {duration: reader.duration, cues: reader.cues, title: "add duration and cues (valid seekable file)"},
   ];
   for(const info of infos){
-    const refinedMetadataBuf = tools.putRefinedMetaData(reader.metadatas, info);
+    const refinedMetadataBuf = tools.makeMetadataSeekable(reader.metadatas, reader.duration, reader.cues);
     const webMBuf = await readAsArrayBuffer(webM);
     const body = webMBuf.slice(reader.metadataSize);
     const refinedWebM = new Blob([refinedMetadataBuf, body], {type: webM.type});

--- a/src/example_seekable.ts
+++ b/src/example_seekable.ts
@@ -11,6 +11,7 @@ async function main_from_file() {
   const decoder = new Decoder();
   const reader = new EBMLReader();
   reader.logging = true;
+  reader.logGroup = "Raw WebM file";
   reader.drop_default_duration = false;
   const webMBuf = await fetch("./chrome57.webm").then(res=> res.arrayBuffer());
   const elms = decoder.decode(webMBuf);
@@ -23,6 +24,16 @@ async function main_from_file() {
   refined_video.src = URL.createObjectURL(refinedWebM);
   refined_video.controls = true;
   document.body.appendChild(refined_video);
+
+  // Log the refined WebM file structure.
+  const refinedDecoder = new Decoder();
+  const refinedReader = new EBMLReader();  
+  refinedReader.logging = true;
+  refinedReader.logGroup = "Refined WebM file";
+  const refinedBuf = await readAsArrayBuffer(refinedWebM);
+  const refinedElms = refinedDecoder.decode(refinedBuf);
+  refinedElms.forEach((elm)=>{ refinedReader.read(elm); });
+  refinedReader.stop();  
 }
 
 async function main_from_recorder() {

--- a/src/test.ts
+++ b/src/test.ts
@@ -207,7 +207,7 @@ function create_convert_to_seekable_test(file: string){
     const sec = reader.duration * reader.timecodeScale / 1000 / 1000 / 1000;
     assert.ok(7 < sec && sec < 11);
 
-    const refinedMetadataBuf = tools.putRefinedMetaData(reader.metadatas, reader);
+    const refinedMetadataBuf = tools.makeMetadataSeekable(reader.metadatas, reader.duration, reader.cues);
     const body = webm_buf.slice(reader.metadataSize);
 
     assert.ok(refinedMetadataBuf.byteLength - reader.metadataSize > 0);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -86,6 +86,353 @@ export function createRIFFChunk(FourCC: string, chunk: Buffer): Buffer {
   ]);
 }
 
+
+/* Original Metadata
+
+ m  0	EBML
+ u  1	  EBMLVersion 1
+ u  1	  EBMLReadVersion 1
+ u  1	  EBMLMaxIDLength 4
+ u  1	  EBMLMaxSizeLength 8
+ s  1	  DocType webm
+ u  1	  DocTypeVersion 4
+ u  1	  DocTypeReadVersion 2
+ m  0	Segment
+ m  1	  Info                                segmentContentStartPos, all CueClusterPositions provided in info.cues will be relative to here and will need adjusted
+ u  2	    TimecodeScale 1000000
+ 8  2	    MuxingApp Chrome
+ 8  2	    WritingApp Chrome
+ m  1	  Tracks                              tracksStartPos
+ m  2	    TrackEntry
+ u  3	      TrackNumber 1
+ u  3	      TrackUID 31790271978391090
+ u  3	      TrackType 2
+ s  3	      CodecID A_OPUS
+ b  3	      CodecPrivate <Buffer 19>
+ m  3	      Audio
+ f  4	        SamplingFrequency 48000
+ u  4	        Channels 1
+ m  2	    TrackEntry
+ u  3	      TrackNumber 2
+ u  3	      TrackUID 24051277436254136
+ u  3	      TrackType 1
+ s  3	      CodecID V_VP8
+ m  3	      Video
+ u  4	        PixelWidth 1024
+ u  4	        PixelHeight 576
+ m  1	  Cluster                             clusterStartPos
+ u  2	    Timecode 0
+ b  2	    SimpleBlock track:2 timecode:0	keyframe:true	invisible:false	discardable:false	lacing:1
+*/
+
+/* Desired Metadata
+
+ m	0 EBML
+ u	1   EBMLVersion 1
+ u	1   EBMLReadVersion 1
+ u	1   EBMLMaxIDLength 4
+ u	1   EBMLMaxSizeLength 8
+ s	1   DocType webm
+ u	1   DocTypeVersion 4
+ u	1   DocTypeReadVersion 2
+ m	0 Segment
+ m	1   SeekHead                            -> This is SeekPosition 0, so all SeekPositions can be calculated as (bytePos - segmentContentStartPos), which is 44 in this case
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x15, 0x49, 0xA9, 0x66])  Info
+ u	3       SeekPosition                    -> infoStartPos = 
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x16, 0x54, 0xAE, 0x6B])  Tracks
+ u	3       SeekPosition { tracksStartPos }
+ m	2     Seek
+ b	3       SeekID                          -> Buffer([0x1C, 0x53, 0xBB, 0x6B])  Cues
+ u	3       SeekPosition { cuesStartPos }   
+ m	1   Info
+ f	2     Duration 32480                    -> overwrite, or insert if it doesn't exist
+ u	2     TimecodeScale 1000000
+ 8	2     MuxingApp Chrome
+ 8	2     WritingApp Chrome
+ m	1   Tracks
+ m	2     TrackEntry
+ u	3       TrackNumber 1
+ u	3       TrackUID 31790271978391090
+ u	3       TrackType 2
+ s	3       CodecID A_OPUS
+ b	3       CodecPrivate <Buffer 19>
+ m	3       Audio
+ f	4         SamplingFrequency 48000
+ u	4         Channels 1
+ m	2     TrackEntry
+ u	3       TrackNumber 2
+ u	3       TrackUID 24051277436254136
+ u	3       TrackType 1
+ s	3       CodecID V_VP8
+ m	3       Video
+ u	4         PixelWidth 1024
+ u	4         PixelHeight 576
+ m  1   Cues                                -> cuesStartPos
+ m  2     CuePoint
+ u  3       CueTime 0
+ m  3       CueTrackPositions
+ u  4         CueTrack 1
+ u  4         CueClusterPosition 3911
+ m  2     CuePoint
+ u  3       CueTime 600
+ m  3       CueTrackPositions
+ u  4         CueTrack 1
+ u  4         CueClusterPosition 3911
+ m  1   Cluster
+ u  2     Timecode 0
+ b  2     SimpleBlock track:2 timecode:0	keyframe:true	invisible:false	discardable:false	lacing:1
+*/
+
+/**
+ * convert the metadata from a streaming webm bytestream to a seekable file by inserting Duration, Seekhead and Cues
+ * @param originalMetadata - orginal metadata (everything before the clusters start) from media recorder
+ * @param duration - Duration (TimecodeScale)
+ * @param cues - cue points for clusters
+ */
+export function makeMetadataSeekable( 
+
+  originalMetadata: EBML.EBMLElementDetail[], 
+  duration: number,
+  cuesInfo: {CueTrack: number; CueClusterPosition: number; CueTime: number; }[] )
+
+  : ArrayBuffer {
+
+  // extract the header, we can reuse this as-is
+  let header = extractElement("EBML", originalMetadata);
+  let headerSize = encodedSizeOfEbml(header);
+  //console.error("Header size: " + headerSize);
+  //printElementIds(header);
+
+  // After the header comes the Segment open tag, which in this implementation is always 12 bytes (4 byte id, 8 byte 'unknown length')
+  // After that the segment content starts. All SeekPositions and CueClusterPosition must be relative to segmentContentStartPos
+  let segmentContentStartPos = headerSize + 12;
+  //console.error("segmentContentStartPos: " + segmentContentStartPos);    
+
+  // find the original metadata size, and adjust it for header size and Segment start element so we can keep all positions relative to segmentContentStartPos
+  
+  let originalMetadataSize = originalMetadata[originalMetadata.length-1].dataEnd - segmentContentStartPos;
+  //console.error("Original Metadata size: " + originalMetadataSize);
+  //printElementIds(originalMetadata);
+
+  // extract the segment info, remove the potentially existing Duration element, and add our own one.
+  let info : EBML.EBMLElementBuffer[] = extractElement("Info", originalMetadata);
+  removeElement("Duration", info);
+  info.splice(1,0, {name: "Duration", type: "f", data: createFloatBuffer(duration, 8) })
+  let infoSize = encodedSizeOfEbml(info);
+  //console.error("Info size: " + infoSize);
+  //printElementIds(info);  
+
+  // extract the track info, we can re-use this as is
+  let tracks = extractElement("Tracks", originalMetadata)
+  let tracksSize = encodedSizeOfEbml(tracks);
+  //console.error("Tracks size: " + tracksSize);
+  //printElementIds(tracks);  
+
+  let seekHeadSize = 47;                        // Initial best guess, but could be slightly larger if the Cues element is huge.
+  let seekHead : EBML.EBMLElementBuffer[] = [];
+
+  let cuesSize = 5 + cuesInfo.length * 15;      // very rough initial approximation, depends a lot on file size and number of CuePoints                   
+  let cues : EBML.EBMLElementBuffer[] = [];
+
+  let lastSizeDifference = -1;  // 
+
+  // The size of SeekHead and Cues elements depends on how many bytes the offsets values can be encoded in.
+  // The actual offsets in CueClusterPosition depend on the final size of the SeekHead and Cues elements
+  // We need to iteratively converge to a stable solution.
+
+  const maxIterations = 10;
+  for (let i = 0; i < maxIterations; i++) {
+
+    // SeekHead starts at 0
+    let infoStart = seekHeadSize;                 // Info comes directly after SeekHead
+    let tracksStart = infoStart + infoSize;       // Tracks comes directly after Info
+    let cuesStart = tracksStart + tracksSize;     // Cues starts directly after 
+    let newMetadataSize = cuesStart + cuesSize;   // total size of metadata  
+
+    // This is the offset all CueClusterPositions should be adjusted by due to the metadata size changing.
+    let sizeDifference = newMetadataSize - originalMetadataSize;
+    // console.error(`infoStart: ${infoStart}, infoSize: ${infoSize}`);
+    // console.error(`tracksStart: ${tracksStart}, tracksSize: ${tracksSize}`);
+    // console.error(`cuesStart: ${cuesStart}, cuesSize: ${cuesSize}`);
+    // console.error(`originalMetadataSize: ${originalMetadataSize}, newMetadataSize: ${newMetadataSize}, sizeDifference: ${sizeDifference}`); 
+
+    // create the SeekHead element
+    seekHead = [];
+    seekHead.push({name: "SeekHead", type: "m", isEnd: false});
+      seekHead.push({name: "Seek", type: "m", isEnd: false});
+        seekHead.push({name: "SeekID", type: "b", data: new Buffer([0x15, 0x49, 0xA9, 0x66])});   // Info
+        seekHead.push({name: "SeekPosition", type: "u", data: createUIntBuffer(infoStart)});
+      seekHead.push({name: "Seek", type: "m", isEnd: true});
+      seekHead.push({name: "Seek", type: "m", isEnd: false});
+        seekHead.push({name: "SeekID", type: "b", data: new Buffer([0x16, 0x54, 0xAE, 0x6B])});   // Tracks
+        seekHead.push({name: "SeekPosition", type: "u", data: createUIntBuffer(tracksStart)});
+      seekHead.push({name: "Seek", type: "m", isEnd: true});
+      seekHead.push({name: "Seek", type: "m", isEnd: false});
+        seekHead.push({name: "SeekID", type: "b", data: new Buffer([0x1C, 0x53, 0xBB, 0x6B])});   // Cues
+        seekHead.push({name: "SeekPosition", type: "u", data: createUIntBuffer(cuesStart)});
+      seekHead.push({name: "Seek", type: "m", isEnd: true});        
+    seekHead.push({name: "SeekHead", type: "m", isEnd: true});
+
+    seekHeadSize = encodedSizeOfEbml(seekHead);
+    //console.error("SeekHead size: " + seekHeadSize);
+    //printElementIds(seekHead);  
+
+    // create the Cues element
+    cues = [];
+    cues.push({name: "Cues", type: "m", isEnd: false}) 
+      cuesInfo.forEach(({ CueTrack, CueClusterPosition, CueTime }) => {
+        cues.push({ name: "CuePoint", type: "m", isEnd: false });
+          cues.push({ name: "CueTime", type: "u", data: createUIntBuffer(CueTime) });
+          cues.push({ name: "CueTrackPositions", type: "m", isEnd: false });
+            cues.push({ name: "CueTrack", type: "u", data: createUIntBuffer(CueTrack) });
+            //console.error(`CueClusterPosition: ${CueClusterPosition}, Corrected to: ${CueClusterPosition - segmentContentStartPos}  , offset by ${sizeDifference} to become ${(CueClusterPosition - segmentContentStartPos) + sizeDifference - segmentContentStartPos}`);
+            // EBMLReader returns CueClusterPosition with absolute byte offsets. The Cues section expects them as offsets from the first level 1 element of the Segment, so we need to adjust it.
+            CueClusterPosition -= segmentContentStartPos;
+            // We also need to adjust to take into account the change in metadata size from when EBMLReader read the original metadata.
+            CueClusterPosition += sizeDifference;
+            cues.push({ name: "CueClusterPosition", type: "u", data: createUIntBuffer(CueClusterPosition) });
+          cues.push({ name: "CueTrackPositions", type: "m", isEnd: true });
+        cues.push({ name: "CuePoint", type: "m", isEnd: true });
+      });
+    cues.push({name: "Cues", type: "m", isEnd: true}) 
+
+    cuesSize = encodedSizeOfEbml(cues);
+    //console.error("Cues size: " + cuesSize);   
+    //console.error("Cue count: " + cuesInfo.length);
+    //printElementIds(cues);      
+
+    // If the new MetadataSize is not the same as the previous iteration, we need to run once more.
+    if (lastSizeDifference !== sizeDifference){
+      lastSizeDifference = sizeDifference;
+
+      if (i === maxIterations-1) {
+        throw new Error("Failed to converge to a stable metadata size");
+      }
+
+    } else {
+      // We're done! Construct the new metadata from all individual components and return.
+      //console.error(`Final size: ${newMetadataSize}, difference: ${sizeDifference}`);
+      break;
+    }
+  }
+
+  let finalMetadata: EBML.EBMLElementDetail[] = [].concat.apply([],
+    [
+      header,
+      { name: "Segment", type: "m", isEnd: false, unknownSize: true },
+      seekHead,
+      info,
+      tracks,
+      cues
+    ]);
+  
+  let result = new Encoder().encode(finalMetadata);
+  //printElementIds(finalMetadata);
+  //console.error(`Final metadata buffer size: ${result.byteLength}`);
+  //console.error(`Final metadata buffer size without header and segment: ${result.byteLength-segmentContentStartPos}`);
+  return result;  
+}
+
+/**
+ * print all element id names in a list
+
+ * @param metadata - array of EBML elements to print
+ *
+export function printElementIds(metadata: EBML.EBMLElementBuffer[]) {
+
+  let result: EBML.EBMLElementBuffer[] = [];
+  let start: number = -1;
+
+  for (let i = 0; i < metadata.length; i++) {
+    console.error("\t id: " + metadata[i].name);
+  }
+}
+*/
+
+/**
+ * remove all occurances of an EBML element from an array of elements
+ * If it's a MasterElement you will also remove the content. (everything between start and end)
+ * @param idName - name of the EBML Element to remove.
+ * @param metadata - array of EBML elements to search
+ */
+export function removeElement(idName: string, metadata: EBML.EBMLElementBuffer[]) {
+
+  let result: EBML.EBMLElementBuffer[] = [];
+  let start: number = -1;
+
+  for (let i = 0; i < metadata.length; i++) {
+
+    let element = metadata[i];
+
+    if (element.name === idName) {
+
+      // if it's a Master element, extract the start and end element, and everything in between
+      if (element.type === "m") {
+
+        if (!element.isEnd) {
+          start = i;
+        } else {
+          // we've reached the end, extract the whole thing
+          if (start == -1)
+            throw new Error(`Detected ${idName} closing element before finding the start`)
+
+          metadata.splice(start, i - start + 1);
+          return;
+        }
+
+      } else {
+        // not a Master element, so we've found what we're looking for.
+        metadata.splice(i, 1);
+        return;
+      }
+    }
+  }
+}
+
+/**
+ * extract the first occurance of an EBML tag from a flattened array of EBML data. 
+ * If it's a MasterElement you will also get the content. (everything between start and end)
+ * @param idName - name of the EBML Element to extract.
+ * @param metadata - array of EBML elements to search
+ */
+export function extractElement(idName: string, metadata: EBML.EBMLElementBuffer[]): EBML.EBMLElementBuffer[] {
+
+  let result: EBML.EBMLElementBuffer[] = [];
+  let start: number = -1;
+
+  for (let i = 0; i < metadata.length; i++) {
+
+    let element = metadata[i];
+
+    if (element.name === idName) {
+
+      // if it's a Master element, extract the start and end element, and everything in between
+      if (element.type === "m") {
+
+        if (!element.isEnd) {
+          start = i;
+        } else {
+          // we've reached the end, extract the whole thing
+          if (start == -1)
+            throw new Error(`Detected ${idName} closing element before finding the start`)
+
+          result = metadata.slice(start, i + 1);
+          break;
+        }
+
+      } else {
+        // not a Master element, so we've found what we're looking for.
+        result.push(metadata[i]);
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
 /**
  * metadata に対して duration と seekhead を追加した metadata を返す
  * @param metadata - 変更前の webm における ファイル先頭から 最初の Cluster 要素までの 要素

--- a/test/example_seekable.html
+++ b/test/example_seekable.html
@@ -1,1 +1,8 @@
-<script src="example_seekable.js"></script>
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <script src="example_seekable.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Inserts SeekHead with pointer to Info, Tracks and Cues, inserts or replaces Duration, and adds Cues.
Fixes up all offsets to be relative the first element of Segment content as per spec.

Improved logging and the examples somewhat to help with debugging tasks I had.

tested on latest firefox and chrome, all tests pass on both.