### PR TITLE
Ensure using buffer object

### DIFF
--- a/src/EBMLEncoder.ts
+++ b/src/EBMLEncoder.ts
@@ -39,6 +39,8 @@ export default class EBMLEncoder {
         this.endTag(elm);
       }
     }else{
+      // ensure that we are working with an internal `Buffer` instance
+      elm.data = Buffer.from(elm.data);
       this.writeTag(elm);
     }
     return this.flush();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -648,23 +648,8 @@ function insertTag(_metadata: EBML.EBMLElementBuffer[], tagName: string, childre
 }
 
 
-// alter Buffer.concat - https://github.com/feross/buffer/issues/154
 export function concat(list: Buffer[]): Buffer {
-  //return Buffer.concat.apply(Buffer, list);
-  let i = 0;
-  let length = 0;
-  for (; i < list.length; ++i) {
-    length += list[i].length;
-  }
-
-  let buffer = Buffer.allocUnsafe(length);
-  let pos = 0;
-  for (i = 0; i < list.length; ++i) {
-    let buf = list[i];
-    buf.copy(buffer, pos);
-    pos += buf.length;
-  }
-  return buffer;
+  return Buffer.concat(list);
 }
 
 export function encodeValueToBuffer(elm: EBML.MasterElement): EBML.MasterElement;


### PR DESCRIPTION
It is useful to be able to provide a `Uint8Array` when building the EBML, but currently this results in an error when `Buffer.concat` is used because this is expecting an instance of `Buffer`. This PR ensures that `data` is always converted to a `Buffer` instance.