### PR TITLE
Make reader adhere to latest matroska schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ebml-block": "^1.1.0",
     "events": "^1.1.1",
     "int64-buffer": "^0.1.9",
-    "matroska": "^2.2.3"
+    "matroska": "^2.2.5"
   },
   "devDependencies": {
     "@types/commander": "^2.9.1",

--- a/src/EBMLReader.ts
+++ b/src/EBMLReader.ts
@@ -212,9 +212,9 @@ export default class EBMLReader extends EventEmitter {
       this.emit_segment_info();
       this.emit("cluster_ptr", elm.tagStart);
       this.lastClusterPosition = elm.tagStart;
-    }else if(elm.type === "u" && elm.name === "Timecode"){
+    }else if(elm.type === "u" && elm.name === "Timestamp"){
       this.lastClusterTimecode = elm.value;
-    }else if(elm.type === "u" && elm.name === "TimecodeScale"){
+    }else if(elm.type === "u" && elm.name === "TimestampScale"){
       this.timecodeScale = elm.value;
     }else if(elm.type === "m" && elm.name === "TrackEntry"){
       if(elm.isEnd){


### PR DESCRIPTION
Spent a ton of time chasing down this bug. Due to the dependency version `^2.2.3` for `matroska` ts-ebml fetches the latest `2.2.5` when installing now. A patch-release shouldn't contain breaking changes, but in fact the schema was updated between `2.2.3` and `2.2.5` renaming Timecode -> Timestamp and TimecodeScale to TimestampScale. This is also mentioned in the [matroska spec](https://www.matroska.org/technical/notes.html)

> Historically timestamps in Matroska were mistakenly called timecodes. The Timestamp Element was called Timecode, the TimestampScale Element was called TimecodeScale, the TrackTimestampScale Element was called TrackTimecodeScale and the ReferenceTimestamp Element was called ReferenceTimeCode.

With this fix, files multiple clusters will finally report correct duration :)